### PR TITLE
Added support for password_from_file option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ vm-export=my-second-vm
 vm-export=my-third-vm
 ```
 
-password to connect to the XenAPI (required): `password=sup3rs3cr37`
+password to connect to the XenAPI (required): Either via `password=sup3rs3cr37` or `password_from_file=/root/server01.pwd`
 
 location of the logfile (default `/var/log/NAUbackup.log`): `status_log=/path/to/file.log`
 

--- a/VmBackup.py
+++ b/VmBackup.py
@@ -49,7 +49,7 @@ MAIL_FROM_ADDR = 'your-from-address@your-domain'
 MAIL_SMTP_SERVER = 'your-mail-server'
 
 config = {}
-expected_keys = ['pool_db_backup', 'max_backups', 'backup_dir', 'vm-export', 'status_log', 'password', 'pool_host']
+expected_keys = ['pool_db_backup', 'max_backups', 'backup_dir', 'vm-export', 'status_log', 'password', 'password_from_file', 'pool_host']
 message = ''
 xe_path = '/opt/xensource/bin'
 
@@ -694,7 +694,17 @@ if __name__ == '__main__':
         print 'ERROR in configuration settings...'
         sys.exit(1)
 
-    password = config['password']
+    if 'password' in config:
+        password = config['password']
+    else:
+        if 'password_from_file' in config:
+            infile = open(config['password_from_file'], 'r')
+            password = infile.readline().strip()
+            infile.close()
+        else:
+            print 'ERROR in configuration: No password provided'
+            sys.exit(1)
+
     status_log = config['status_log']
 
     # acquire a xapi session by logging in

--- a/example.cfg
+++ b/example.cfg
@@ -26,6 +26,8 @@ vm-export=my-third-vm
 
 # password for the XenAPI
 password=sup3rs3cr37
+# alternatively supply password from extra file
+#password_from_file=/root/server01.pwd
 
 # log file
 status_log=/var/log/NAUbackup.log


### PR DESCRIPTION
Hello Michael,

I've added support for a `password_from_file` option as an alternative to `password` .
Now I can move the config file onto the nfs share on the backup target and allow the backup operator to update the the list of VM's he wants to backup, without sharing the root password with him and without leaving the root password lying around on an nfs share. Yes, call me old fashioned ;-)

cheers
-henrik